### PR TITLE
o1js Pack edits for product name and zkApp content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# O1JS Pack
+# o1js Pack
 
-Make the most of your ZKApp state!
+Make the most of your zkApp state!
 
 ## What is it
 
-O1JS Pack is a library for [O1JS](https://github.com/o1-labs/o1js/) that allows a zkapp developer to pack extra data into a single Field.
+o1js Pack is a library for [O1JS](https://github.com/o1-labs/o1js/) that allows a zkApp developer to pack extra data into a single Field.
 
-### Usage in a ZKApp
+### Usage in a zkApp
 
 ```
 import {
@@ -25,9 +25,9 @@ const myPackedUInts = new MyPackedUInts(MyPackedUInts.pack(sevenUints), sevenUin
 
 ## What's the catch?
 
-If a zkapp has two or more independent Fields of state, then preconditions can be set on just one, or on any combination of the Fields. With SnarkyPack, one precondition will be set on the packed Field, which means that independent updates cannot happen asynchronously.
+If a zkApp has two or more independent Fields of state, then preconditions can be set on just one, or on any combination of the Fields. With o1js Pack, one precondition can be set on the packed Field, which means that independent updates cannot happen asynchronously.
 
-For example, let's say there is a voting app with two independent Fields of state: `yesCount` and `noCount`. If one user issues an update to `yesCount` and another user issues an update to `noCount` at the same time, both proofs may be valid at the same time. Both transactions may succeed during the same block, since they don't interfere with each others' preconditions. With SnarkyPack, a devolper can save state by putting both `yesCount` and `noCount` into the same Field of state, making room for other state to exist on chain. The tradeoff is that two votes will no longer be able to be cast independently. `yesCount` and `noCount` depend on the same precontition, meaning that to update one or the other, you must lock both.
+For example, let's say there is a voting app with two independent Fields of state: `yesCount` and `noCount`. If one user issues an update to `yesCount` and another user issues an update to `noCount` at the same time, both proofs may be valid at the same time. Both transactions may succeed during the same block, since they don't interfere with each others' preconditions. With o1js Pack, a developer can save state by putting both `yesCount` and `noCount` into the same Field of state, making room for other states to exist on chain. The tradeoff is that two votes will no longer be able to be cast independently. `yesCount` and `noCount` depend on the same precontition, meaning that to update one or the other, you must lock both.
 
 ## How to build
 
@@ -50,7 +50,7 @@ npm run coverage
 
 ## Credits
 
-Thanks to @mario_zito for seeding the idea for this library on discord ([Thread 1](https://discord.com/channels/484437221055922177/1128509274465779822), [Thread 2](https://discord.com/channels/484437221055922177/1128501705173106698)), and to @gregor for sounding out the early implementation.
+Thanks to @mario_zito for seeding the idea for this library on Discord ([Thread 1](https://discord.com/channels/484437221055922177/1128509274465779822), [Thread 2](https://discord.com/channels/484437221055922177/1128501705173106698)), and to @gregor for sounding out the early implementation.
 
 Thanks to @iam-dev for early adoption!
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Make the most of your zkApp state!
 
 ## What is it
 
-o1js Pack is a library for [O1JS](https://github.com/o1-labs/o1js/) that allows a zkApp developer to pack extra data into a single Field.
+o1js Pack is a library for [o1js](https://github.com/o1-labs/o1js/) that allows a zkApp developer to pack extra data into a single Field.
 
 ### Usage in a zkApp
 


### PR DESCRIPTION
This PR updates the content to elevate the o1js brand (lower case o1js in all cases), see [o1js](https://github.com/o1-labs/docs2/wiki/Word-List#o1js) in our word list. Let me know if you have questions.

Thank you, Coby, for your community package contribution. @45930 