### PR TITLE
adding assertion to unpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,32 +2,17 @@
 
 Make the most of your ZKApp state!
 
-## What is it
-
 O1JS Pack is a library for [O1JS](https://github.com/o1-labs/o1js/) that allows a zkapp developer to pack extra data into a single Field.
 
-### Usage in a ZKApp
+## Examples
 
-```
-import {
-  PackedBoolFactory,
-  PackedStringFactory,
-  PackedUInt32Factory,
-} from 'o1js-pack';
+TODO
 
-const MyPackedBools = PackedBoolFactory(); // Max of 254 Bools
-const MyPackedString = PackedStringFactory(); // Max of 120 Characters
-const MyPackedUInts = PackedUInt32Factory(); // Max of 7 UInt32s
+### Smart Contract
 
-const sevenUints = [1, 2, 3, 4, 5, 6, 7].map(x => UInt32.from(x));
-const myPackedUInts = new MyPackedUInts(MyPackedUInts.pack(sevenUints), sevenUints);
-```
+### ZK Program
 
-## What's the catch?
-
-If a zkapp has two or more independent Fields of state, then preconditions can be set on just one, or on any combination of the Fields. With SnarkyPack, one precondition will be set on the packed Field, which means that independent updates cannot happen asynchronously.
-
-For example, let's say there is a voting app with two independent Fields of state: `yesCount` and `noCount`. If one user issues an update to `yesCount` and another user issues an update to `noCount` at the same time, both proofs may be valid at the same time. Both transactions may succeed during the same block, since they don't interfere with each others' preconditions. With SnarkyPack, a devolper can save state by putting both `yesCount` and `noCount` into the same Field of state, making room for other state to exist on chain. The tradeoff is that two votes will no longer be able to be cast independently. `yesCount` and `noCount` depend on the same precontition, meaning that to update one or the other, you must lock both.
+## How to Extend Packing Plant with Custom Types
 
 ## How to build
 
@@ -39,13 +24,7 @@ npm run build
 
 ```sh
 npm run test src # non-proof tests
-npm run testw # watch mode
-```
-
-## How to run coverage
-
-```sh
-npm run coverage
+npm run test tests/provable # provable tests
 ```
 
 ## Credits

--- a/src/lib/PackingPlant.ts
+++ b/src/lib/PackingPlant.ts
@@ -142,7 +142,7 @@ export function MultiPackingPlant<
      * @throws if the length of the array is longer than the length of the implementing factory config
      */
     static checkPack(unpacked: Array<T>) {
-      if (unpacked.length > this.totalLength()) {
+      if (unpacked.length > this.l) {
         throw new Error(
           `Input of size ${unpacked.length} is larger than expected size of ${l}`
         );
@@ -188,7 +188,7 @@ export function MultiPackingPlant<
      * @returns Array of bigints, which can be decoded by the implementing class into the final type
      */
     static unpackToBigints(fields: Array<Field>): Array<bigint> {
-      let uints_ = new Array(this.totalLength()); // array length is number of elements per field * number of fields
+      let uints_ = new Array(this.l); // array length is number of elements per field * number of fields
       uints_.fill(0n);
       let packedNs = new Array(this.n);
       packedNs.fill(0n);
@@ -214,15 +214,6 @@ export function MultiPackingPlant<
         }
       }
       return uints_;
-    }
-
-    /**
-     * total length of the unpacked data, including dummy values packed at the end
-     * differs from static l in that l is the length of the useful input data, ignoring dummy values
-     * @returns number of elements in the raw unpacked data
-     */
-    static totalLength(): number {
-      return this.elementsPerField() * this.n;
     }
 
     assertEquals(other: Packed_) {

--- a/src/lib/PackingPlant.ts
+++ b/src/lib/PackingPlant.ts
@@ -142,8 +142,7 @@ export function MultiPackingPlant<
      * @throws if the length of the array is longer than the length of the implementing factory config
      */
     static checkPack(unpacked: Array<T>) {
-      const q = this.elementsPerField();
-      if (unpacked.length > q * this.n) {
+      if (unpacked.length > this.totalLength()) {
         throw new Error(
           `Input of size ${unpacked.length} is larger than expected size of ${l}`
         );
@@ -189,8 +188,7 @@ export function MultiPackingPlant<
      * @returns Array of bigints, which can be decoded by the implementing class into the final type
      */
     static unpackToBigints(fields: Array<Field>): Array<bigint> {
-      const q = this.elementsPerField();
-      let uints_ = new Array(q * this.n); // array length is number of elements per field * number of fields
+      let uints_ = new Array(this.totalLength()); // array length is number of elements per field * number of fields
       uints_.fill(0n);
       let packedNs = new Array(this.n);
       packedNs.fill(0n);
@@ -216,6 +214,15 @@ export function MultiPackingPlant<
         }
       }
       return uints_;
+    }
+
+    /**
+     * total length of the unpacked data, including dummy values packed at the end
+     * differs from static l in that l is the length of the useful input data, ignoring dummy values
+     * @returns number of elements in the raw unpacked data
+     */
+    static totalLength(): number {
+      return this.elementsPerField() * this.n;
     }
 
     assertEquals(other: Packed_) {

--- a/src/lib/packed-types/PackedBool.ts
+++ b/src/lib/packed-types/PackedBool.ts
@@ -24,6 +24,7 @@ export function PackedBoolFactory(l: number = L) {
         const unpacked = this.unpackToBigints(f);
         return unpacked.map((x) => Bool.fromJSON(Boolean(x)));
       });
+      f.assertEquals(PackedBool_.pack(unpacked));
       return unpacked;
     }
 

--- a/src/lib/packed-types/PackedString.test.ts
+++ b/src/lib/packed-types/PackedString.test.ts
@@ -4,7 +4,7 @@ import { PackedStringFactory, MultiPackedStringFactory } from './PackedString';
 describe('PackedString', () => {
   describe('Outside of the Circuit', () => {
     const vitalik_dot_eth = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
-    class EthAddressString extends MultiPackedStringFactory(42) {}
+    class EthAddressString extends MultiPackedStringFactory(3) {}
     let characters: Array<Character> = [];
 
     beforeEach(() => {
@@ -31,9 +31,9 @@ describe('PackedString', () => {
       const packed = EthAddressString.pack(unpacked);
 
       expect(packed.length).toBe(Math.ceil(vitalik_dot_eth.length / 15));
-      expect(unpacked.length).toBe(EthAddressString.totalLength());
+      expect(unpacked.length).toBe(EthAddressString.l);
       expect(unpacked.length).toBe(45);
-      expect(unpacked.slice(0, EthAddressString.l).toString()).toBe(
+      expect(unpacked.slice(0, characters.length).toString()).toBe(
         characters.toString()
       );
     });
@@ -41,8 +41,8 @@ describe('PackedString', () => {
   describe('Provable Properties', () => {
     it('#sizeInFields', () => {
       class one extends PackedStringFactory(15) {}
-      class two extends MultiPackedStringFactory(16) {}
-      class three extends MultiPackedStringFactory(40) {}
+      class two extends MultiPackedStringFactory(2) {}
+      class three extends MultiPackedStringFactory(3) {}
 
       expect(one.sizeInFields()).toBe(1);
       expect(two.sizeInFields()).toBe(2);
@@ -68,7 +68,7 @@ describe('PackedString', () => {
     });
     it('Exceeds maximum size string', () => {
       const tooLong = 'too long!'.repeat(20);
-      class MaxString extends MultiPackedStringFactory(120) {}
+      class MaxString extends MultiPackedStringFactory(8) {}
       expect(() => {
         MaxString.fromString(tooLong);
       }).toThrow();
@@ -76,7 +76,7 @@ describe('PackedString', () => {
   });
   describe('In the circuit', () => {
     const vitalik_dot_eth = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
-    class EthAddressString extends MultiPackedStringFactory(42) {}
+    class EthAddressString extends MultiPackedStringFactory(3) {}
 
     const outsideEthAddress = EthAddressString.fromString(vitalik_dot_eth);
 

--- a/src/lib/packed-types/PackedString.ts
+++ b/src/lib/packed-types/PackedString.ts
@@ -36,7 +36,12 @@ export function PackedStringFactory(l: number = L) {
      * @param characters Array of Character to be packed
      * @returns Instance of the implementing class
      */
-    static fromCharacters(characters: Array<Character>): PackedString_ {
+    static fromCharacters(input: Array<Character>): PackedString_ {
+      let characters: Array<Character> = new Array(this.l);
+      characters.fill(new Character(Field(0)), 0, this.l);
+      for (let i = 0; i < input.length; i++) {
+        characters[i] = input[i];
+      }
       const packed = this.pack(characters);
       return new PackedString_(packed);
     }
@@ -47,7 +52,11 @@ export function PackedStringFactory(l: number = L) {
      * @returns Instance of the implementing class
      */
     static fromString(str: string): PackedString_ {
-      const characters = str.split('').map((x) => Character.fromString(x));
+      let characters: Array<Character> = new Array(this.l);
+      characters.fill(new Character(Field(0)), 0, this.l);
+      for (let i = 0; i < str.length; i++) {
+        characters[i] = Character.fromString(str[i]);
+      }
       return this.fromCharacters(characters);
     }
 
@@ -85,9 +94,8 @@ export function MultiPackedStringFactory(l: number) {
      * @returns Array of Character
      */
     static unpack(fields: Field[]): Character[] {
-      const q = this.elementsPerField();
       const unpacked = Provable.witness(
-        Provable.Array(Character, q * this.n),
+        Provable.Array(Character, this.totalLength()),
         () => {
           let unpacked = this.unpackToBigints(fields);
           return unpacked.map((x) =>
@@ -106,7 +114,12 @@ export function MultiPackedStringFactory(l: number) {
      * @param characters Array of Character to be packed
      * @returns Instance of the implementing class
      */
-    static fromCharacters(characters: Array<Character>): MultiPackedString_ {
+    static fromCharacters(input: Array<Character>): MultiPackedString_ {
+      let characters: Array<Character> = new Array(this.totalLength());
+      characters.fill(new Character(Field(0)), 0, this.totalLength());
+      for (let i = 0; i < input.length; i++) {
+        characters[i] = input[i];
+      }
       const packed = this.pack(characters);
       return new MultiPackedString_(packed);
     }
@@ -117,9 +130,8 @@ export function MultiPackedStringFactory(l: number) {
      * @returns Instance of the implementing class
      */
     static fromString(str: string): MultiPackedString_ {
-      const q = this.elementsPerField();
-      let characters: Array<Character> = new Array(q * this.n);
-      characters.fill(new Character(Field(0)), 0, q * this.n);
+      let characters: Array<Character> = new Array(this.totalLength());
+      characters.fill(new Character(Field(0)), 0, this.totalLength());
       for (let i = 0; i < str.length; i++) {
         characters[i] = Character.fromString(str[i]);
       }

--- a/src/lib/packed-types/PackedString.ts
+++ b/src/lib/packed-types/PackedString.ts
@@ -70,10 +70,15 @@ export function PackedStringFactory(l: number = L) {
   return PackedString_;
 }
 
-export function MultiPackedStringFactory(l: number) {
+/**
+ *
+ * @param n number of fields to employ to store the string
+ * @returns MultiPackedString_ class with length of n * CHARS_PER_FIELD
+ */
+export function MultiPackedStringFactory(n = 8) {
   class MultiPackedString_ extends MultiPackingPlant(
     Character,
-    l,
+    n * CHARS_PER_FIELD,
     SIZE_IN_BITS
   ) {
     static extractField(input: Character): Field {
@@ -95,7 +100,7 @@ export function MultiPackedStringFactory(l: number) {
      */
     static unpack(fields: Field[]): Character[] {
       const unpacked = Provable.witness(
-        Provable.Array(Character, this.totalLength()),
+        Provable.Array(Character, this.l),
         () => {
           let unpacked = this.unpackToBigints(fields);
           return unpacked.map((x) =>
@@ -115,8 +120,8 @@ export function MultiPackedStringFactory(l: number) {
      * @returns Instance of the implementing class
      */
     static fromCharacters(input: Array<Character>): MultiPackedString_ {
-      let characters: Array<Character> = new Array(this.totalLength());
-      characters.fill(new Character(Field(0)), 0, this.totalLength());
+      let characters: Array<Character> = new Array(this.l);
+      characters.fill(new Character(Field(0)), 0, this.l);
       for (let i = 0; i < input.length; i++) {
         characters[i] = input[i];
       }
@@ -130,8 +135,8 @@ export function MultiPackedStringFactory(l: number) {
      * @returns Instance of the implementing class
      */
     static fromString(str: string): MultiPackedString_ {
-      let characters: Array<Character> = new Array(this.totalLength());
-      characters.fill(new Character(Field(0)), 0, this.totalLength());
+      let characters: Array<Character> = new Array(this.l);
+      characters.fill(new Character(Field(0)), 0, this.l);
       for (let i = 0; i < str.length; i++) {
         characters[i] = Character.fromString(str[i]);
       }

--- a/src/lib/packed-types/PackedString.ts
+++ b/src/lib/packed-types/PackedString.ts
@@ -1,4 +1,4 @@
-import { Field, Provable, Character } from 'o1js';
+import { Field, Provable, Character, Poseidon } from 'o1js';
 import { MultiPackingPlant } from '../PackingPlant.js';
 
 const SIZE_IN_BITS = 16n;
@@ -31,6 +31,9 @@ export function PackedStringFactory(l: number = L) {
           Character.fromString(String.fromCharCode(Number(x)))
         );
       });
+      Poseidon.hash(fields).assertEquals(
+        Poseidon.hash(PackedString_.pack(unpacked))
+      );
       return unpacked;
     }
 

--- a/src/lib/packed-types/PackedString.ts
+++ b/src/lib/packed-types/PackedString.ts
@@ -1,12 +1,12 @@
 import { Field, Provable, Character, Poseidon } from 'o1js';
-import { MultiPackingPlant } from '../PackingPlant.js';
+import { PackingPlant, MultiPackingPlant } from '../PackingPlant.js';
 
 const SIZE_IN_BITS = 16n;
 const L = 15; // Default to one-field worth of characters
 const CHARS_PER_FIELD = 15;
 
 export function PackedStringFactory(l: number = L) {
-  class PackedString_ extends MultiPackingPlant(Character, l, SIZE_IN_BITS) {
+  class PackedString_ extends PackingPlant(Character, l, SIZE_IN_BITS) {
     static extractField(input: Character): Field {
       return input.value;
     }
@@ -15,25 +15,19 @@ export function PackedStringFactory(l: number = L) {
       return SIZE_IN_BITS;
     }
 
-    static elementsPerField(): number {
-      return CHARS_PER_FIELD;
-    }
-
     /**
      *
-     * @param fields Array of Fields, containing packed Characters
+     * @param f Field, packed with the information, as returned by #pack
      * @returns Array of Character
      */
-    static unpack(fields: Field[]): Character[] {
+    static unpack(f: Field): Character[] {
       const unpacked = Provable.witness(Provable.Array(Character, l), () => {
-        let unpacked = this.unpackToBigints(fields);
+        const unpacked = this.unpackToBigints(f);
         return unpacked.map((x) =>
           Character.fromString(String.fromCharCode(Number(x)))
         );
       });
-      Poseidon.hash(fields).assertEquals(
-        Poseidon.hash(PackedString_.pack(unpacked))
-      );
+      f.assertEquals(PackedString_.pack(unpacked));
       return unpacked;
     }
 
@@ -53,11 +47,7 @@ export function PackedStringFactory(l: number = L) {
      * @returns Instance of the implementing class
      */
     static fromString(str: string): PackedString_ {
-      let characters: Array<Character> = new Array(l);
-      characters.fill(new Character(Field(0)), 0, l);
-      for (let i = 0; i < str.length; i++) {
-        characters[i] = Character.fromString(str[i]);
-      }
+      const characters = str.split('').map((x) => Character.fromString(x));
       return this.fromCharacters(characters);
     }
 
@@ -69,4 +59,79 @@ export function PackedStringFactory(l: number = L) {
     }
   }
   return PackedString_;
+}
+
+export function MultiPackedStringFactory(l: number) {
+  class MultiPackedString_ extends MultiPackingPlant(
+    Character,
+    l,
+    SIZE_IN_BITS
+  ) {
+    static extractField(input: Character): Field {
+      return input.value;
+    }
+
+    static sizeInBits(): bigint {
+      return SIZE_IN_BITS;
+    }
+
+    static elementsPerField(): number {
+      return CHARS_PER_FIELD;
+    }
+
+    /**
+     *
+     * @param fields Array of Fields, containing packed Characters
+     * @returns Array of Character
+     */
+    static unpack(fields: Field[]): Character[] {
+      const q = this.elementsPerField();
+      const unpacked = Provable.witness(
+        Provable.Array(Character, q * this.n),
+        () => {
+          let unpacked = this.unpackToBigints(fields);
+          return unpacked.map((x) =>
+            Character.fromString(String.fromCharCode(Number(x)))
+          );
+        }
+      );
+      Poseidon.hash(fields).assertEquals(
+        Poseidon.hash(MultiPackedString_.pack(unpacked))
+      );
+      return unpacked;
+    }
+
+    /**
+     *
+     * @param characters Array of Character to be packed
+     * @returns Instance of the implementing class
+     */
+    static fromCharacters(characters: Array<Character>): MultiPackedString_ {
+      const packed = this.pack(characters);
+      return new MultiPackedString_(packed);
+    }
+
+    /**
+     *
+     * @param str string to be packed
+     * @returns Instance of the implementing class
+     */
+    static fromString(str: string): MultiPackedString_ {
+      const q = this.elementsPerField();
+      let characters: Array<Character> = new Array(q * this.n);
+      characters.fill(new Character(Field(0)), 0, q * this.n);
+      for (let i = 0; i < str.length; i++) {
+        characters[i] = Character.fromString(str[i]);
+      }
+      return this.fromCharacters(characters);
+    }
+
+    toString() {
+      const nullChar = String.fromCharCode(0);
+      return MultiPackedString_.unpack(this.packed)
+        .filter((c) => c.toString() !== nullChar)
+        .join('');
+    }
+  }
+  return MultiPackedString_;
 }

--- a/src/lib/packed-types/PackedUInt32.ts
+++ b/src/lib/packed-types/PackedUInt32.ts
@@ -24,6 +24,7 @@ export function PackedUInt32Factory(l: number = L) {
         const unpacked = this.unpackToBigints(f);
         return unpacked.map((x) => UInt32.from(x));
       });
+      f.assertEquals(PackedUInt32_.pack(unpacked));
       return unpacked;
     }
 

--- a/tests/provable/end_to_end.test.ts
+++ b/tests/provable/end_to_end.test.ts
@@ -56,12 +56,10 @@ describe('End to End Text Input Test', () => {
       const p1 = await TextInputProgram.changeFirstLetter(
         proofTextInput,
         initProof,
-        TextInput.unpack(new TextInput(initProof.publicInput.packed).packed),
+        TextInput.unpack(initProof.publicInput.packed),
         Character.fromString('Z')
       );
-      Poseidon.hash(proofTextInput.packed).assertEquals(
-        Poseidon.hash(p1.publicInput.packed)
-      );
+      proofTextInput.assertEquals(p1.publicInput);
     });
   });
 });

--- a/tests/provable/example_packed_string_circuit.ts
+++ b/tests/provable/example_packed_string_circuit.ts
@@ -6,10 +6,10 @@ import {
   Provable,
   Field,
 } from 'o1js';
-import { PackedStringFactory } from '../../src/lib/packed-types/PackedString';
+import { MultiPackedStringFactory } from '../../src/lib/packed-types/PackedString';
 
 const MAX_LENGTH = 32;
-export class TextInput extends PackedStringFactory(MAX_LENGTH) {}
+export class TextInput extends MultiPackedStringFactory(MAX_LENGTH) {}
 
 export const TextInputProgram = Experimental.ZkProgram({
   publicInput: TextInput,

--- a/tests/provable/example_packed_string_circuit.ts
+++ b/tests/provable/example_packed_string_circuit.ts
@@ -8,8 +8,7 @@ import {
 } from 'o1js';
 import { MultiPackedStringFactory } from '../../src/lib/packed-types/PackedString';
 
-const MAX_LENGTH = 32;
-export class TextInput extends MultiPackedStringFactory(MAX_LENGTH) {}
+export class TextInput extends MultiPackedStringFactory(3) {}
 
 export const TextInputProgram = Experimental.ZkProgram({
   publicInput: TextInput,
@@ -23,11 +22,7 @@ export const TextInputProgram = Experimental.ZkProgram({
       },
     },
     changeFirstLetter: {
-      privateInputs: [
-        SelfProof,
-        Provable.Array(Character, MAX_LENGTH),
-        Character,
-      ],
+      privateInputs: [SelfProof, Provable.Array(Character, 45), Character],
       method(
         newState: TextInput,
         oldProof: SelfProof<TextInput, TextInput>,

--- a/tests/provable/example_packed_uint_circuit.ts
+++ b/tests/provable/example_packed_uint_circuit.ts
@@ -18,24 +18,18 @@ export const VotesProgram = Experimental.ZkProgram({
       privateInputs: [SelfProof],
       method(newState: Votes, oldProof: SelfProof<Votes, Votes>) {
         oldProof.verify();
-        const expectedUnpacked = Votes.unpack(oldProof.publicInput.packed);
-        oldProof.publicInput.packed.assertEquals(
-          Votes.fromUInt32s(expectedUnpacked).packed
-        );
-        expectedUnpacked[0] = expectedUnpacked[0].add(1);
-        newState.assertEquals(Votes.fromUInt32s(expectedUnpacked));
+        const unpacked = Votes.unpack(oldProof.publicInput.packed);
+        unpacked[0] = unpacked[0].add(1);
+        newState.assertEquals(Votes.fromUInt32s(unpacked));
       },
     },
     incrementIndex1: {
       privateInputs: [SelfProof],
       method(newState: Votes, oldProof: SelfProof<Votes, Votes>) {
         oldProof.verify();
-        const expectedUnpacked = Votes.unpack(oldProof.publicInput.packed);
-        oldProof.publicInput.packed.assertEquals(
-          Votes.fromUInt32s(expectedUnpacked).packed
-        );
-        expectedUnpacked[1] = expectedUnpacked[1].add(1);
-        newState.assertEquals(Votes.fromUInt32s(expectedUnpacked));
+        const unpacked = Votes.unpack(oldProof.publicInput.packed);
+        unpacked[1] = unpacked[1].add(1);
+        newState.assertEquals(Votes.fromUInt32s(unpacked));
       },
     },
   },


### PR DESCRIPTION
Cleaning up some of the provable code, including adding assertions to `unpack` so that users don't have to assert it themselves.

Also fixes some issues with the `MultiPackPlant` used for longer strings, by enforcing that strings be a multiple of 15 characters (15 characters in one packed Field).  Previously, there were frustrating runtime errors in proofs when length % 0 != 0.